### PR TITLE
feat(game): driver cockpit prototype + browser compatibility & game loop

### DIFF
--- a/game/css/retro-effects.css
+++ b/game/css/retro-effects.css
@@ -1,0 +1,260 @@
+/* === VHS/CRT RETRO EFFECTS === */
+
+/* Scanlines Effect */
+.scanlines {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(
+        rgba(18, 16, 16, 0) 50%, 
+        rgba(0, 0, 0, 0.25) 50%
+    );
+    background-size: 100% 4px;
+    z-index: 20;
+    pointer-events: none;
+    animation: scanlines-move 8s linear infinite;
+}
+
+@keyframes scanlines-move {
+    0% { background-position: 0 0; }
+    100% { background-position: 0 8px; }
+}
+
+/* Vignette Effect */
+.vignette {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    box-shadow: inset 0 0 150px rgba(0, 0, 0, 0.8);
+    z-index: 21;
+    pointer-events: none;
+}
+
+/* VHS Overlay with Noise and Chromatic Aberration */
+.vhs-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 22;
+    pointer-events: none;
+    opacity: 0.3;
+    background: 
+        repeating-linear-gradient(
+            0deg,
+            rgba(0, 0, 0, 0.15),
+            rgba(0, 0, 0, 0.15) 1px,
+            transparent 1px,
+            transparent 2px
+        );
+    animation: vhs-shake 0.1s infinite, vhs-distortion 5s infinite;
+}
+
+@keyframes vhs-shake {
+    0%, 100% { transform: translateX(0) translateY(0); }
+    10% { transform: translateX(-1px) translateY(1px); }
+    20% { transform: translateX(1px) translateY(-1px); }
+    30% { transform: translateX(-1px) translateY(-1px); }
+    40% { transform: translateX(1px) translateY(1px); }
+    50% { transform: translateX(-1px) translateY(1px); }
+    60% { transform: translateX(1px) translateY(-1px); }
+    70% { transform: translateX(-1px) translateY(-1px); }
+    80% { transform: translateX(1px) translateY(1px); }
+    90% { transform: translateX(-1px) translateY(0); }
+}
+
+@keyframes vhs-distortion {
+    0%, 100% { 
+        opacity: 0.3; 
+        transform: scaleX(1);
+    }
+    10% { 
+        opacity: 0.4; 
+        transform: scaleX(1.01);
+    }
+    20% { 
+        opacity: 0.3; 
+        transform: scaleX(1);
+    }
+    30% { 
+        opacity: 0.35; 
+        transform: scaleX(0.99);
+    }
+    40% { 
+        opacity: 0.3; 
+        transform: scaleX(1);
+    }
+}
+
+/* CRT Screen Curvature Simulation */
+#game-container::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: radial-gradient(
+        ellipse at center,
+        rgba(0, 0, 0, 0) 0%,
+        rgba(0, 0, 0, 0.2) 100%
+    );
+    z-index: 23;
+    pointer-events: none;
+}
+
+/* Film Grain Texture */
+#game-container::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200"><filter id="noiseFilter"><feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="4" stitchTiles="stitch"/></filter><rect width="100%" height="100%" filter="url(%23noiseFilter)"/></svg>');
+    opacity: 0.05;
+    z-index: 24;
+    pointer-events: none;
+    animation: grain 8s steps(10) infinite;
+}
+
+@keyframes grain {
+    0%, 100% { transform: translate(0, 0); }
+    10% { transform: translate(-5%, -10%); }
+    20% { transform: translate(-15%, 5%); }
+    30% { transform: translate(7%, -25%); }
+    40% { transform: translate(-5%, 25%); }
+    50% { transform: translate(-15%, 10%); }
+    60% { transform: translate(15%, 0%); }
+    70% { transform: translate(0%, 15%); }
+    80% { transform: translate(3%, 35%); }
+    90% { transform: translate(-10%, 10%); }
+}
+
+/* Chromatic Aberration on Text */
+.glitch-text::before,
+.glitch-text::after {
+    content: attr(data-text);
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.glitch-text::before {
+    left: 2px;
+    text-shadow: -2px 0 #ff00ff;
+    clip: rect(44px, 450px, 56px, 0);
+    animation: glitch-anim 5s infinite linear alternate-reverse;
+}
+
+.glitch-text::after {
+    left: -2px;
+    text-shadow: -2px 0 #00ffff;
+    clip: rect(44px, 450px, 56px, 0);
+    animation: glitch-anim2 5s infinite linear alternate-reverse;
+}
+
+@keyframes glitch-anim {
+    0% { clip: rect(61px, 9999px, 71px, 0); }
+    5% { clip: rect(33px, 9999px, 98px, 0); }
+    10% { clip: rect(5px, 9999px, 17px, 0); }
+    15% { clip: rect(76px, 9999px, 34px, 0); }
+    20% { clip: rect(22px, 9999px, 8px, 0); }
+    25% { clip: rect(91px, 9999px, 52px, 0); }
+    30% { clip: rect(43px, 9999px, 88px, 0); }
+    35% { clip: rect(12px, 9999px, 67px, 0); }
+    40% { clip: rect(58px, 9999px, 23px, 0); }
+    45% { clip: rect(85px, 9999px, 46px, 0); }
+    50% { clip: rect(39px, 9999px, 72px, 0); }
+    55% { clip: rect(66px, 9999px, 15px, 0); }
+    60% { clip: rect(28px, 9999px, 93px, 0); }
+    65% { clip: rect(81px, 9999px, 41px, 0); }
+    70% { clip: rect(7px, 9999px, 55px, 0); }
+    75% { clip: rect(49px, 9999px, 79px, 0); }
+    80% { clip: rect(95px, 9999px, 31px, 0); }
+    85% { clip: rect(18px, 9999px, 64px, 0); }
+    90% { clip: rect(73px, 9999px, 9px, 0); }
+    95% { clip: rect(36px, 9999px, 87px, 0); }
+    100% { clip: rect(54px, 9999px, 25px, 0); }
+}
+
+@keyframes glitch-anim2 {
+    0% { clip: rect(26px, 9999px, 99px, 0); }
+    5% { clip: rect(70px, 9999px, 36px, 0); }
+    10% { clip: rect(15px, 9999px, 82px, 0); }
+    15% { clip: rect(48px, 9999px, 11px, 0); }
+    20% { clip: rect(92px, 9999px, 57px, 0); }
+    25% { clip: rect(4px, 9999px, 74px, 0); }
+    30% { clip: rect(63px, 9999px, 29px, 0); }
+    35% { clip: rect(19px, 9999px, 85px, 0); }
+    40% { clip: rect(77px, 9999px, 42px, 0); }
+    45% { clip: rect(31px, 9999px, 68px, 0); }
+    50% { clip: rect(88px, 9999px, 16px, 0); }
+    55% { clip: rect(45px, 9999px, 93px, 0); }
+    60% { clip: rect(2px, 9999px, 59px, 0); }
+    65% { clip: rect(71px, 9999px, 24px, 0); }
+    70% { clip: rect(37px, 9999px, 80px, 0); }
+    75% { clip: rect(94px, 9999px, 46px, 0); }
+    80% { clip: rect(12px, 9999px, 65px, 0); }
+    85% { clip: rect(56px, 9999px, 21px, 0); }
+    90% { clip: rect(83px, 9999px, 38px, 0); }
+    95% { clip: rect(27px, 9999px, 90px, 0); }
+    100% { clip: rect(60px, 9999px, 5px, 0); }
+}
+
+/* Horizontal Distortion Bars (VHS Tracking Issues) */
+@keyframes distortion-bar {
+    0% { 
+        top: -10%; 
+        height: 2%;
+    }
+    100% { 
+        top: 110%; 
+        height: 2%;
+    }
+}
+
+.vhs-overlay::before {
+    content: '';
+    position: absolute;
+    width: 100%;
+    height: 2%;
+    background: rgba(255, 255, 255, 0.1);
+    animation: distortion-bar 8s linear infinite;
+}
+
+/* Color Shift Effect */
+@keyframes color-shift {
+    0%, 100% { filter: hue-rotate(0deg) saturate(1); }
+    50% { filter: hue-rotate(5deg) saturate(1.2); }
+}
+
+#gameCanvas {
+    animation: color-shift 10s ease-in-out infinite;
+}
+
+/* Flickering Light Effect */
+@keyframes flicker {
+    0%, 100% { opacity: 1; }
+    41.99% { opacity: 1; }
+    42% { opacity: 0.8; }
+    43% { opacity: 1; }
+    45.99% { opacity: 1; }
+    46% { opacity: 0.6; }
+    46.5% { opacity: 1; }
+    51% { opacity: 1; }
+    51.99% { opacity: 0.7; }
+    52% { opacity: 1; }
+}
+
+/* Apply flicker to dashboard occasionally */
+.left-panel {
+    animation: flicker 15s infinite;
+}

--- a/game/css/style.css
+++ b/game/css/style.css
@@ -1,0 +1,337 @@
+/* === RESET & BASE === */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Courier New', monospace;
+    background: #000;
+    color: #fff;
+    overflow: hidden;
+    user-select: none;
+}
+
+/* === GAME CONTAINER === */
+#game-container {
+    position: relative;
+    width: 100vw;
+    height: 100vh;
+    background: #000;
+    overflow: hidden;
+}
+
+#gameCanvas {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+/* === UI CONTAINER === */
+#ui-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 10;
+}
+
+/* === CENTER MESSAGE === */
+#center-message {
+    position: absolute;
+    top: 44%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    text-align: center;
+    font-size: 2.35rem;
+    font-weight: bold;
+    padding: 10px 18px;
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.28);
+    text-shadow: 0 0 10px rgba(255, 0, 0, 0.5);
+    animation: pulse 2s ease-in-out infinite;
+}
+
+.glitch-text {
+    position: relative;
+    color: #fff;
+    text-shadow: 
+        0.05em 0 0 rgba(255, 0, 0, 0.75),
+        -0.025em -0.05em 0 rgba(0, 255, 0, 0.75),
+        0.025em 0.05em 0 rgba(0, 0, 255, 0.75);
+    animation: glitch 500ms infinite;
+}
+
+@keyframes glitch {
+    0% {
+        text-shadow: 
+            0.05em 0 0 rgba(255, 0, 0, 0.75),
+            -0.025em -0.05em 0 rgba(0, 255, 0, 0.75),
+            0.025em 0.05em 0 rgba(0, 0, 255, 0.75);
+    }
+    14% {
+        text-shadow: 
+            0.05em 0 0 rgba(255, 0, 0, 0.75),
+            -0.025em -0.05em 0 rgba(0, 255, 0, 0.75),
+            0.025em 0.05em 0 rgba(0, 0, 255, 0.75);
+    }
+    15% {
+        text-shadow: 
+            -0.05em -0.025em 0 rgba(255, 0, 0, 0.75),
+            0.025em 0.025em 0 rgba(0, 255, 0, 0.75),
+            -0.05em -0.05em 0 rgba(0, 0, 255, 0.75);
+    }
+    49% {
+        text-shadow: 
+            -0.05em -0.025em 0 rgba(255, 0, 0, 0.75),
+            0.025em 0.025em 0 rgba(0, 255, 0, 0.75),
+            -0.05em -0.05em 0 rgba(0, 0, 255, 0.75);
+    }
+    50% {
+        text-shadow: 
+            0.025em 0.05em 0 rgba(255, 0, 0, 0.75),
+            0.05em 0 0 rgba(0, 255, 0, 0.75),
+            0 -0.05em 0 rgba(0, 0, 255, 0.75);
+    }
+    99% {
+        text-shadow: 
+            0.025em 0.05em 0 rgba(255, 0, 0, 0.75),
+            0.05em 0 0 rgba(0, 255, 0, 0.75),
+            0 -0.05em 0 rgba(0, 0, 255, 0.75);
+    }
+    100% {
+        text-shadow: 
+            0.05em 0 0 rgba(255, 0, 0, 0.75),
+            -0.025em -0.05em 0 rgba(0, 255, 0, 0.75),
+            0.025em 0.05em 0 rgba(0, 0, 255, 0.75);
+    }
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 0.8; }
+    50% { opacity: 1; }
+}
+
+/* === PANELS === */
+.panel {
+    position: absolute;
+    background: rgba(0, 0, 0, 0.8);
+    border: 2px solid #333;
+    border-radius: 5px;
+    padding: 15px;
+    font-size: 0.9rem;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.5);
+}
+
+.left-panel {
+    bottom: 16px;
+    left: 20px;
+    width: 200px;
+}
+
+.right-panel {
+    top: 20px;
+    right: 20px;
+    width: 250px;
+    max-height: 400px;
+    overflow-y: auto;
+}
+
+/* === DASHBOARD === */
+.gauge {
+    margin-bottom: 15px;
+}
+
+.gauge-label {
+    font-size: 0.75rem;
+    color: #888;
+    margin-bottom: 5px;
+}
+
+.gauge-value {
+    font-size: 1.5rem;
+    font-weight: bold;
+    color: #0f0;
+    text-shadow: 0 0 5px #0f0;
+}
+
+.gauge-progress {
+    width: 100%;
+    height: 10px;
+    background: #222;
+    border: 1px solid #444;
+    border-radius: 3px;
+    overflow: hidden;
+}
+
+.gauge-fill {
+    height: 100%;
+    background: linear-gradient(90deg, #0f0 0%, #ff0 50%, #f00 100%);
+    transition: width 0.3s ease;
+}
+
+.warning-lights {
+    display: flex;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.warning-light {
+    flex: 1;
+    padding: 5px;
+    text-align: center;
+    font-size: 0.65rem;
+    background: #222;
+    border: 1px solid #444;
+    border-radius: 3px;
+    color: #666;
+    transition: all 0.3s ease;
+}
+
+.warning-light.active {
+    background: #ff3d00;
+    color: #fff;
+    border-color: #ff3d00;
+    box-shadow: 0 0 14px #ff3d00;
+    animation: blink 0.5s infinite;
+}
+
+@keyframes blink {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+}
+
+/* === DOCUMENT PANEL === */
+.document-header {
+    font-size: 1rem;
+    font-weight: bold;
+    border-bottom: 2px solid #444;
+    padding-bottom: 8px;
+    margin-bottom: 12px;
+    color: #888;
+}
+
+.route-info {
+    margin-bottom: 15px;
+}
+
+.route-info p {
+    margin: 5px 0;
+    font-size: 0.85rem;
+}
+
+.document-notes {
+    border-top: 1px solid #333;
+    padding-top: 10px;
+    margin-top: 10px;
+}
+
+.note-text {
+    font-size: 0.8rem;
+    margin: 8px 0;
+    font-style: italic;
+    color: #ccc;
+}
+
+.note-text.faded {
+    color: #666;
+    animation: fade-flicker 3s infinite;
+}
+
+@keyframes fade-flicker {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 0.7; }
+}
+
+/* === GAME STATE MESSAGE === */
+.state-message {
+    position: absolute;
+    top: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: rgba(255, 0, 0, 0.8);
+    padding: 10px 20px;
+    border-radius: 5px;
+    font-size: 1.2rem;
+    font-weight: bold;
+    text-align: center;
+    box-shadow: 0 0 20px rgba(255, 0, 0, 0.5);
+    animation: slideDown 0.5s ease-out;
+}
+
+@keyframes slideDown {
+    from {
+        top: -50px;
+        opacity: 0;
+    }
+    to {
+        top: 20px;
+        opacity: 1;
+    }
+}
+
+/* === SCREENS === */
+.screen {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background: rgba(0, 0, 0, 0.95);
+    z-index: 100;
+    pointer-events: all;
+}
+
+.screen.hidden {
+    display: none;
+}
+
+.loading-content,
+.pause-content,
+.gameover-content {
+    text-align: center;
+    padding: 40px;
+}
+
+.loading-content h1,
+.gameover-content h2 {
+    font-size: 4rem;
+    margin-bottom: 20px;
+}
+
+.pause-content h2 {
+    font-size: 3rem;
+    margin-bottom: 20px;
+}
+
+.loading-content p,
+.pause-content p,
+.gameover-content p {
+    font-size: 1.5rem;
+    margin: 10px 0;
+}
+
+.controls-hint {
+    margin-top: 40px;
+    font-size: 1rem;
+    color: #888;
+}
+
+.controls-hint p {
+    font-size: 1rem;
+    margin: 5px 0;
+}
+
+/* === UTILITY CLASSES === */
+.hidden {
+    display: none !important;
+}

--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bus Shift - Horror Bus Game</title>
+    <link rel="stylesheet" href="css/style.css">
+    <link rel="stylesheet" href="css/retro-effects.css">
+</head>
+<body>
+    <!-- Main Game Container -->
+    <div id="game-container">
+        <!-- VHS/CRT Overlay Effects -->
+        <div class="vhs-overlay"></div>
+        <div class="scanlines"></div>
+        <div class="vignette"></div>
+        
+        <!-- Main Canvas -->
+        <canvas id="gameCanvas"></canvas>
+        
+        <!-- UI Overlays -->
+        <div id="ui-container">
+            <!-- Center Message -->
+            <div id="center-message" class="message-box">
+                <p class="glitch-text">Stay on the road...</p>
+            </div>
+            
+            <!-- Dashboard Panel (Left) -->
+            <div id="dashboard" class="panel left-panel">
+                <div class="gauge" id="speed-gauge">
+                    <div class="gauge-label">SPEED</div>
+                    <div class="gauge-value">0 km/h</div>
+                </div>
+                <div class="gauge" id="fuel-gauge">
+                    <div class="gauge-label">FUEL</div>
+                    <div class="gauge-progress">
+                        <div class="gauge-fill" style="width: 100%"></div>
+                    </div>
+                </div>
+                <div class="warning-lights">
+                    <div class="warning-light" id="engine-light">ENGINE</div>
+                    <div class="warning-light" id="brake-light">BRAKE</div>
+                </div>
+            </div>
+            
+            <!-- Document/Map Panel (Right) -->
+            <div id="document-panel" class="panel right-panel">
+                <div class="document-header">ROUTE MAP</div>
+                <div class="document-content">
+                    <div class="route-info">
+                        <p><strong>Route:</strong> 66-B</p>
+                        <p><strong>Destination:</strong> ???</p>
+                        <p><strong>Distance:</strong> Unknown</p>
+                    </div>
+                    <div class="document-notes">
+                        <p class="note-text">Keep driving. Don't look back.</p>
+                        <p class="note-text faded">Something is following...</p>
+                    </div>
+                </div>
+            </div>
+            
+            <!-- Game State Messages -->
+            <div id="game-state-message" class="state-message hidden"></div>
+        </div>
+        
+        <!-- Loading Screen -->
+        <div id="loading-screen" class="screen">
+            <div class="loading-content">
+                <h1 class="glitch-text">BUS SHIFT</h1>
+                <p>Press SPACE to start</p>
+                <div class="controls-hint">
+                    <p>Controls:</p>
+                    <p>← → or A/D - Steer</p>
+                    <p>↑ or W - Accelerate</p>
+                    <p>↓ or S - Brake</p>
+                    <p>ESC - Pause</p>
+                </div>
+            </div>
+        </div>
+        
+        <!-- Pause Screen -->
+        <div id="pause-screen" class="screen hidden">
+            <div class="pause-content">
+                <h2>PAUSED</h2>
+                <p>Press ESC to continue</p>
+            </div>
+        </div>
+        
+        <!-- Game Over Screen -->
+        <div id="gameover-screen" class="screen hidden">
+            <div class="gameover-content">
+                <h2 class="glitch-text">YOU LEFT THE ROAD</h2>
+                <p id="gameover-message"></p>
+                <p>Press SPACE to restart</p>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Game Scripts -->
+    <script src="js/config.js"></script>
+    <script src="js/utils.js"></script>
+    <script src="js/controls.js"></script>
+    <script src="js/renderer.js"></script>
+    <script src="js/horror.js"></script>
+    <script src="js/audio.js"></script>
+    <script src="js/game.js"></script>
+    <script src="js/main.js"></script>
+</body>
+</html>

--- a/game/js/audio.js
+++ b/game/js/audio.js
@@ -1,0 +1,192 @@
+// Audio System - Manages game sounds (engine, ambience, effects)
+
+const AUDIO_CONFIG = (typeof window !== 'undefined' && window.CONFIG)
+    ? window.CONFIG
+    : require('./config.js');
+
+class AudioSystem {
+    constructor() {
+        // Audio context
+        this.audioContext = null;
+        this.initialized = false;
+        
+        // Audio nodes
+        this.engineOscillator = null;
+        this.engineGain = null;
+        this.ambientOscillator = null;
+        this.ambientGain = null;
+        this.masterGain = null;
+        
+        // State
+        this.engineRunning = false;
+        this.currentSpeed = 0;
+    }
+    
+    async init() {
+        try {
+            // Create audio context (requires user interaction)
+            this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+            
+            // Master gain (volume control)
+            this.masterGain = this.audioContext.createGain();
+            this.masterGain.gain.value = AUDIO_CONFIG.audio.masterVolume;
+            this.masterGain.connect(this.audioContext.destination);
+            
+            this.initialized = true;
+            console.log('Audio system initialized');
+        } catch (error) {
+            console.warn('Audio initialization failed:', error);
+        }
+    }
+    
+    startEngine() {
+        if (!this.initialized || this.engineRunning) return;
+        
+        try {
+            // Engine sound (low frequency oscillator)
+            this.engineOscillator = this.audioContext.createOscillator();
+            this.engineOscillator.type = 'sawtooth';
+            this.engineOscillator.frequency.value = 40; // Low rumble
+            
+            this.engineGain = this.audioContext.createGain();
+            this.engineGain.gain.value = 0;
+            
+            this.engineOscillator.connect(this.engineGain);
+            this.engineGain.connect(this.masterGain);
+            
+            this.engineOscillator.start();
+            this.engineRunning = true;
+        } catch (error) {
+            console.warn('Engine start failed:', error);
+        }
+    }
+    
+    stopEngine() {
+        if (!this.engineRunning || !this.engineOscillator) return;
+        
+        try {
+            this.engineOscillator.stop();
+            this.engineRunning = false;
+        } catch (error) {
+            console.warn('Engine stop failed:', error);
+        }
+    }
+    
+    updateEngineSound(speed) {
+        if (!this.initialized || !this.engineRunning) return;
+        
+        this.currentSpeed = speed;
+        
+        // Frequency increases with speed (40-200 Hz)
+        const frequency = 40 + (speed / AUDIO_CONFIG.bus.maxSpeed) * 160;
+        this.engineOscillator.frequency.linearRampToValueAtTime(
+            frequency,
+            this.audioContext.currentTime + 0.1
+        );
+        
+        // Volume increases with speed
+        const volume = (speed / AUDIO_CONFIG.bus.maxSpeed) * AUDIO_CONFIG.audio.engineVolume;
+        this.engineGain.gain.linearRampToValueAtTime(
+            volume,
+            this.audioContext.currentTime + 0.1
+        );
+    }
+    
+    startAmbient() {
+        if (!this.initialized) return;
+        
+        try {
+            // Ambient horror sound (very low frequency)
+            this.ambientOscillator = this.audioContext.createOscillator();
+            this.ambientOscillator.type = 'sine';
+            this.ambientOscillator.frequency.value = 20; // Sub-bass
+            
+            this.ambientGain = this.audioContext.createGain();
+            this.ambientGain.gain.value = AUDIO_CONFIG.audio.ambientVolume;
+            
+            this.ambientOscillator.connect(this.ambientGain);
+            this.ambientGain.connect(this.masterGain);
+            
+            this.ambientOscillator.start();
+        } catch (error) {
+            console.warn('Ambient start failed:', error);
+        }
+    }
+    
+    stopAmbient() {
+        if (this.ambientOscillator) {
+            try {
+                this.ambientOscillator.stop();
+            } catch (error) {
+                console.warn('Ambient stop failed:', error);
+            }
+        }
+    }
+    
+    playCollisionSound() {
+        if (!this.initialized) return;
+        
+        try {
+            // Sharp noise burst for collision
+            const oscillator = this.audioContext.createOscillator();
+            oscillator.type = 'square';
+            oscillator.frequency.value = 100;
+            
+            const gain = this.audioContext.createGain();
+            gain.gain.value = AUDIO_CONFIG.audio.effectsVolume;
+            gain.gain.linearRampToValueAtTime(0, this.audioContext.currentTime + 0.2);
+            
+            oscillator.connect(gain);
+            gain.connect(this.masterGain);
+            
+            oscillator.start();
+            oscillator.stop(this.audioContext.currentTime + 0.2);
+        } catch (error) {
+            console.warn('Collision sound failed:', error);
+        }
+    }
+    
+    playWhisperSound() {
+        if (!this.initialized) return;
+        
+        try {
+            // Eerie whisper-like noise
+            const oscillator = this.audioContext.createOscillator();
+            oscillator.type = 'sine';
+            oscillator.frequency.value = 400;
+            oscillator.frequency.linearRampToValueAtTime(200, this.audioContext.currentTime + 1);
+            
+            const gain = this.audioContext.createGain();
+            gain.gain.value = 0;
+            gain.gain.linearRampToValueAtTime(AUDIO_CONFIG.audio.effectsVolume * 0.3, this.audioContext.currentTime + 0.5);
+            gain.gain.linearRampToValueAtTime(0, this.audioContext.currentTime + 2);
+            
+            oscillator.connect(gain);
+            gain.connect(this.masterGain);
+            
+            oscillator.start();
+            oscillator.stop(this.audioContext.currentTime + 2);
+        } catch (error) {
+            console.warn('Whisper sound failed:', error);
+        }
+    }
+    
+    setMasterVolume(volume) {
+        if (this.masterGain) {
+            this.masterGain.gain.value = volume;
+        }
+    }
+    
+    reset() {
+        this.stopEngine();
+        this.stopAmbient();
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.AudioSystem = AudioSystem;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = AudioSystem;
+}

--- a/game/js/config.js
+++ b/game/js/config.js
@@ -1,0 +1,97 @@
+// Game Configuration
+const CONFIG = {
+    // Canvas settings
+    canvas: {
+        width: 1280,
+        height: 720,
+        backgroundColor: '#000'
+    },
+    
+    // Road settings
+    road: {
+        width: 400,
+        lanes: 2,
+        lineWidth: 10,
+        lineLength: 40,
+        lineGap: 20,
+        scrollSpeed: 5,
+        sideMargin: 100
+    },
+    
+    // Bus settings
+    bus: {
+        x: 0, // Center of road
+        y: 0, // Will be calculated
+        width: 80,
+        height: 120,
+        speed: 0,
+        maxSpeed: 150,
+        acceleration: 0.5,
+        deceleration: 0.3,
+        turnSpeed: 3,
+        maxTurn: 200
+    },
+    
+    // Environment settings
+    environment: {
+        fogDensity: 0.7,
+        fogColor: '#2a2a2a',
+        treeSpacing: 200,
+        treeCount: 20,
+        skyColor: '#1a1a1a',
+        groundColor: '#0a0a0a'
+    },
+    
+    // Horror mechanics
+    horror: {
+        tensionBuildRate: 0.001,
+        maxTension: 1.0,
+        glitchChance: 0.01,
+        shadowChance: 0.005,
+        whisperChance: 0.002,
+        shakeIntensity: 2,
+        distortionIntensity: 0.05
+    },
+    
+    // Dashboard settings
+    dashboard: {
+        steeringWheelRadius: 60,
+        steeringWheelColor: '#222',
+        instrumentPanelHeight: 120,
+        gaugeRadius: 40
+    },
+    
+    // Game states
+    states: {
+        LOADING: 'loading',
+        MENU: 'menu',
+        PLAYING: 'playing',
+        PAUSED: 'paused',
+        GAMEOVER: 'gameover'
+    },
+    
+    // Physics
+    physics: {
+        gravity: 0.5,
+        friction: 0.95,
+        offRoadFriction: 0.8,
+        offRoadPenalty: 2
+    },
+    
+    // Audio settings (placeholder for future)
+    audio: {
+        engineVolume: 0.5,
+        ambientVolume: 0.3,
+        effectsVolume: 0.7,
+        masterVolume: 0.8
+    }
+};
+
+if (typeof window !== 'undefined') {
+    window.CONFIG = CONFIG;
+}
+
+// Export for use in other modules
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = CONFIG;
+}

--- a/game/js/controls.js
+++ b/game/js/controls.js
@@ -1,0 +1,121 @@
+// Keyboard Controls for Bus Shift
+
+class Controls {
+    constructor() {
+        this.keys = {};
+        this.previousKeys = {};
+        
+        // Key mappings
+        this.mappings = {
+            // Steering
+            left: ['ArrowLeft', 'KeyA'],
+            right: ['ArrowRight', 'KeyD'],
+            
+            // Acceleration/Braking
+            accelerate: ['ArrowUp', 'KeyW'],
+            brake: ['ArrowDown', 'KeyS'],
+            
+            // Game controls
+            pause: ['Escape'],
+            start: ['Space'],
+            restart: ['Space']
+        };
+        
+        // Bind event listeners
+        this.bindEvents();
+    }
+    
+    bindEvents() {
+        window.addEventListener('keydown', (e) => this.onKeyDown(e));
+        window.addEventListener('keyup', (e) => this.onKeyUp(e));
+        
+        // Prevent default behavior for game keys
+        window.addEventListener('keydown', (e) => {
+            const allKeys = Object.values(this.mappings).flat();
+            if (allKeys.includes(e.code)) {
+                e.preventDefault();
+            }
+        });
+    }
+    
+    onKeyDown(e) {
+        this.keys[e.code] = true;
+    }
+    
+    onKeyUp(e) {
+        this.keys[e.code] = false;
+    }
+    
+    /**
+     * Check if a control is currently pressed
+     */
+    isPressed(control) {
+        const codes = this.mappings[control];
+        if (!codes) return false;
+        
+        return codes.some(code => this.keys[code]);
+    }
+    
+    /**
+     * Check if a control was just pressed this frame
+     */
+    isJustPressed(control) {
+        const codes = this.mappings[control];
+        if (!codes) return false;
+        
+        return codes.some(code => 
+            this.keys[code] && !this.previousKeys[code]
+        );
+    }
+    
+    /**
+     * Get steering input (-1 to 1)
+     */
+    getSteeringInput() {
+        let input = 0;
+        if (this.isPressed('left')) input -= 1;
+        if (this.isPressed('right')) input += 1;
+        return input;
+    }
+    
+    /**
+     * Get acceleration input (-1 to 1)
+     */
+    getAccelerationInput() {
+        let input = 0;
+        if (this.isPressed('accelerate')) input += 1;
+        if (this.isPressed('brake')) input -= 1;
+        return input;
+    }
+    
+    /**
+     * Update previous keys state (call at end of frame)
+     */
+    update() {
+        this.previousKeys = { ...this.keys };
+    }
+    
+    /**
+     * Reset all keys
+     */
+    reset() {
+        this.keys = {};
+        this.previousKeys = {};
+    }
+    
+    /**
+     * Disable controls
+     */
+    disable() {
+        this.reset();
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.Controls = Controls;
+}
+
+// Export for use in other modules
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Controls;
+}

--- a/game/js/game.js
+++ b/game/js/game.js
@@ -1,0 +1,241 @@
+// Core game loop and state manager
+
+class Game {
+    constructor() {
+        this.canvas = document.getElementById('gameCanvas');
+        this.ctx = this.canvas.getContext('2d');
+
+        this.controls = new Controls();
+        this.renderer = new Renderer(this.canvas, this.ctx);
+        this.horror = new HorrorSystem();
+        this.audio = new AudioSystem();
+
+        this.state = CONFIG.states.LOADING;
+        this.lastTime = 0;
+
+        this.gameState = {
+            speed: 0,
+            fuel: 100,
+            distance: 0,
+            offRoadTime: 0,
+            tension: 0,
+            bus: {
+                x: 0,
+                steerAngle: 0
+            }
+        };
+
+        this.ui = {
+            loadingScreen: document.getElementById('loading-screen'),
+            pauseScreen: document.getElementById('pause-screen'),
+            gameOverScreen: document.getElementById('gameover-screen'),
+            gameOverMessage: document.getElementById('gameover-message'),
+            centerMessage: document.getElementById('center-message'),
+            centerText: document.querySelector('#center-message .glitch-text'),
+            stateMessage: document.getElementById('game-state-message'),
+            speedValue: document.querySelector('#speed-gauge .gauge-value'),
+            fuelFill: document.querySelector('#fuel-gauge .gauge-fill'),
+            engineLight: document.getElementById('engine-light'),
+            brakeLight: document.getElementById('brake-light')
+        };
+
+        this.resizeCanvas();
+        this.bindEvents();
+        this.syncGlitchDataText();
+    }
+
+    bindEvents() {
+        window.addEventListener('resize', () => this.resizeCanvas());
+    }
+
+    resizeCanvas() {
+        this.canvas.width = CONFIG.canvas.width;
+        this.canvas.height = CONFIG.canvas.height;
+    }
+
+    syncGlitchDataText() {
+        const glitchEls = document.querySelectorAll('.glitch-text');
+        glitchEls.forEach((el) => {
+            if (!el.getAttribute('data-text')) {
+                el.setAttribute('data-text', el.textContent || '');
+            }
+        });
+    }
+
+    start() {
+        this.loop = this.loop.bind(this);
+        requestAnimationFrame(this.loop);
+    }
+
+    loop(timestamp) {
+        const deltaTime = this.lastTime ? (timestamp - this.lastTime) / 1000 : 0;
+        this.lastTime = timestamp;
+
+        this.handleStateTransitions();
+
+        if (this.state === CONFIG.states.PLAYING) {
+            this.updatePlaying(deltaTime);
+        }
+
+        this.render();
+        this.controls.update();
+
+        requestAnimationFrame(this.loop);
+    }
+
+    handleStateTransitions() {
+        if ((this.state === CONFIG.states.LOADING || this.state === CONFIG.states.MENU) && this.controls.isJustPressed('start')) {
+            this.startGame();
+        }
+
+        if (this.state === CONFIG.states.PLAYING && this.controls.isJustPressed('pause')) {
+            this.pauseGame();
+        } else if (this.state === CONFIG.states.PAUSED && this.controls.isJustPressed('pause')) {
+            this.resumeGame();
+        }
+
+        if (this.state === CONFIG.states.GAMEOVER && this.controls.isJustPressed('restart')) {
+            this.restartGame();
+        }
+    }
+
+    async startGame() {
+        if (!this.audio.initialized) {
+            await this.audio.init();
+        }
+
+        this.state = CONFIG.states.PLAYING;
+        this.ui.loadingScreen.classList.add('hidden');
+        this.ui.gameOverScreen.classList.add('hidden');
+        this.ui.pauseScreen.classList.add('hidden');
+
+        this.audio.startEngine();
+        this.audio.startAmbient();
+    }
+
+    pauseGame() {
+        this.state = CONFIG.states.PAUSED;
+        this.ui.pauseScreen.classList.remove('hidden');
+    }
+
+    resumeGame() {
+        this.state = CONFIG.states.PLAYING;
+        this.ui.pauseScreen.classList.add('hidden');
+    }
+
+    restartGame() {
+        this.gameState.speed = 0;
+        this.gameState.fuel = 100;
+        this.gameState.distance = 0;
+        this.gameState.offRoadTime = 0;
+        this.gameState.bus.x = 0;
+        this.gameState.bus.steerAngle = 0;
+        this.horror.reset();
+        this.ui.gameOverScreen.classList.add('hidden');
+        this.state = CONFIG.states.PLAYING;
+    }
+
+    updatePlaying(deltaTime) {
+        const accelerationInput = this.controls.getAccelerationInput();
+        const steeringInput = this.controls.getSteeringInput();
+
+        if (accelerationInput > 0) {
+            this.gameState.speed += CONFIG.bus.acceleration * 60 * deltaTime;
+        } else if (accelerationInput < 0) {
+            this.gameState.speed -= CONFIG.bus.deceleration * 2.2 * 60 * deltaTime;
+        } else {
+            this.gameState.speed -= CONFIG.bus.deceleration * 0.8 * 60 * deltaTime;
+        }
+
+        this.gameState.speed = Utils.clamp(this.gameState.speed, 0, CONFIG.bus.maxSpeed);
+
+        const turnMultiplier = Utils.map(this.gameState.speed, 0, CONFIG.bus.maxSpeed, 0.2, 1);
+        this.gameState.bus.x += steeringInput * CONFIG.bus.turnSpeed * turnMultiplier * 35 * deltaTime;
+        this.gameState.bus.x = Utils.clamp(this.gameState.bus.x, -CONFIG.bus.maxTurn, CONFIG.bus.maxTurn);
+
+        const targetSteerAngle = steeringInput * 35;
+        this.gameState.bus.steerAngle = Utils.lerp(this.gameState.bus.steerAngle, targetSteerAngle, 0.18);
+
+        this.gameState.distance += this.gameState.speed * deltaTime;
+        this.gameState.fuel = Math.max(0, this.gameState.fuel - (this.gameState.speed * 0.0028 + 0.01) * deltaTime);
+
+        this.handleRoadPenalty(deltaTime);
+
+        this.horror.update(deltaTime * 1000);
+        this.gameState.tension = this.horror.getTension();
+
+        this.audio.updateEngineSound(this.gameState.speed);
+
+        this.updateUI();
+
+        if (this.gameState.fuel <= 0 && this.gameState.speed <= 1) {
+            this.triggerGameOver('Você ficou sem combustível no meio da estrada.');
+        }
+    }
+
+    handleRoadPenalty(deltaTime) {
+        const safeLimit = CONFIG.road.width * 0.46;
+        const isOffRoad = Math.abs(this.gameState.bus.x) > safeLimit;
+
+        if (isOffRoad) {
+            this.gameState.offRoadTime += deltaTime;
+            this.gameState.speed = Math.max(0, this.gameState.speed - CONFIG.physics.offRoadPenalty * 40 * deltaTime);
+            this.horror.increaseTension(0.004);
+
+            if (this.gameState.offRoadTime > 2.6) {
+                this.triggerGameOver('Você saiu da pista por tempo demais.');
+            }
+        } else {
+            this.gameState.offRoadTime = Math.max(0, this.gameState.offRoadTime - deltaTime * 1.4);
+        }
+    }
+
+    triggerGameOver(message) {
+        this.state = CONFIG.states.GAMEOVER;
+        this.ui.gameOverMessage.textContent = message;
+        this.ui.gameOverScreen.classList.remove('hidden');
+        this.audio.playCollisionSound();
+    }
+
+    updateUI() {
+        this.ui.speedValue.textContent = `${Math.round(this.gameState.speed)} km/h`;
+
+        const fuelPct = Utils.clamp(this.gameState.fuel, 0, 100);
+        this.ui.fuelFill.style.width = `${fuelPct}%`;
+
+        this.ui.engineLight.classList.toggle('active', this.gameState.fuel < 28 || this.gameState.tension > 0.65);
+        this.ui.brakeLight.classList.toggle('active', this.gameState.offRoadTime > 0.4 || this.controls.isPressed('brake'));
+
+        let centerMsg = 'Stay on the road...';
+        if (this.gameState.offRoadTime > 1.2) {
+            centerMsg = 'Volte para a pista!';
+        } else if (this.gameState.tension > 0.7) {
+            centerMsg = 'Algo está te seguindo...';
+        }
+
+        if (this.ui.centerText.textContent !== centerMsg) {
+            this.ui.centerText.textContent = centerMsg;
+            this.ui.centerText.setAttribute('data-text', centerMsg);
+        }
+    }
+
+    render() {
+        if (this.state === CONFIG.states.PLAYING || this.state === CONFIG.states.PAUSED || this.state === CONFIG.states.GAMEOVER) {
+            const shake = this.horror.getScreenShake();
+            if (shake > 0.01) {
+                this.renderer.applyShake(shake);
+            } else {
+                this.renderer.resetShake();
+            }
+            this.renderer.render(this.gameState);
+        }
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.Game = Game;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Game;
+}

--- a/game/js/horror.js
+++ b/game/js/horror.js
@@ -1,0 +1,210 @@
+// Horror System - Manages tension, glitches, and creepy effects
+
+const HORROR_CONFIG = (typeof window !== 'undefined' && window.CONFIG)
+    ? window.CONFIG
+    : require('./config.js');
+
+const HORROR_UTILS = (typeof window !== 'undefined' && window.Utils)
+    ? window.Utils
+    : require('./utils.js');
+
+class HorrorSystem {
+    constructor() {
+        this.tension = 0;
+        this.glitchActive = false;
+        this.shadowVisible = false;
+        this.whisperTriggered = false;
+        
+        // Effect timers
+        this.glitchTimer = 0;
+        this.shadowTimer = 0;
+        this.whisperTimer = 0;
+    }
+    
+    update(deltaTime) {
+        // Gradually build tension
+        if (this.tension < HORROR_CONFIG.horror.maxTension) {
+            this.tension += HORROR_CONFIG.horror.tensionBuildRate;
+        }
+        
+        // Random horror events based on tension
+        this.checkGlitch();
+        this.checkShadow();
+        this.checkWhisper();
+        
+        // Update effect timers
+        this.updateTimers(deltaTime);
+    }
+    
+    checkGlitch() {
+        if (Math.random() < HORROR_CONFIG.horror.glitchChance * this.tension) {
+            this.triggerGlitch();
+        }
+    }
+    
+    checkShadow() {
+        if (Math.random() < HORROR_CONFIG.horror.shadowChance * this.tension) {
+            this.triggerShadow();
+        }
+    }
+    
+    checkWhisper() {
+        if (Math.random() < HORROR_CONFIG.horror.whisperChance * this.tension) {
+            this.triggerWhisper();
+        }
+    }
+    
+    triggerGlitch() {
+        if (this.glitchActive) return;
+        
+        this.glitchActive = true;
+        this.glitchTimer = 200; // ms
+        
+        // Visual distortion on canvas
+        const canvas = document.getElementById('gameCanvas');
+        if (canvas) {
+            canvas.style.filter = `hue-rotate(${HORROR_UTILS.randomInt(0, 360)}deg) contrast(${HORROR_UTILS.random(1.2, 1.5)})`;
+        }
+        
+        // Message glitch
+        const messageEl = document.getElementById('center-message');
+        if (messageEl && Math.random() < 0.5) {
+            const messages = [
+                "DON'T LOOK BACK",
+                "KEEP DRIVING",
+                "IT'S GETTING CLOSER",
+                "NO ESCAPE",
+                "WHY DID YOU STOP?"
+            ];
+            const originalText = messageEl.textContent;
+            messageEl.textContent = HORROR_UTILS.choose(messages);
+            
+            setTimeout(() => {
+                messageEl.textContent = originalText;
+            }, 300);
+        }
+    }
+    
+    triggerShadow() {
+        if (this.shadowVisible) return;
+        
+        this.shadowVisible = true;
+        this.shadowTimer = 1000; // ms
+        
+        // Flash warning light
+        const warningLights = document.querySelectorAll('.warning-light');
+        warningLights.forEach(light => {
+            light.classList.add('active');
+        });
+    }
+    
+    triggerWhisper() {
+        if (this.whisperTriggered) return;
+        
+        this.whisperTriggered = true;
+        this.whisperTimer = 3000; // ms
+        
+        // Add subtle note to document panel
+        const notesContainer = document.querySelector('.document-notes');
+        if (notesContainer && Math.random() < 0.3) {
+            const whisper = document.createElement('p');
+            whisper.className = 'note-text faded';
+            whisper.textContent = HORROR_UTILS.choose([
+                "I can hear it breathing...",
+                "The mirrors show more than they should...",
+                "Why are the passengers so quiet?",
+                "This road never ends..."
+            ]);
+            notesContainer.appendChild(whisper);
+            
+            setTimeout(() => {
+                whisper.remove();
+            }, 3000);
+        }
+    }
+    
+    updateTimers(deltaTime) {
+        // Glitch timer
+        if (this.glitchActive) {
+            this.glitchTimer -= deltaTime;
+            if (this.glitchTimer <= 0) {
+                this.glitchActive = false;
+                const canvas = document.getElementById('gameCanvas');
+                if (canvas) {
+                    canvas.style.filter = '';
+                }
+            }
+        }
+        
+        // Shadow timer
+        if (this.shadowVisible) {
+            this.shadowTimer -= deltaTime;
+            if (this.shadowTimer <= 0) {
+                this.shadowVisible = false;
+                const warningLights = document.querySelectorAll('.warning-light');
+                warningLights.forEach(light => {
+                    light.classList.remove('active');
+                });
+            }
+        }
+        
+        // Whisper timer
+        if (this.whisperTriggered) {
+            this.whisperTimer -= deltaTime;
+            if (this.whisperTimer <= 0) {
+                this.whisperTriggered = false;
+            }
+        }
+    }
+    
+    getScreenShake() {
+        if (this.glitchActive) {
+            return HORROR_CONFIG.horror.shakeIntensity * this.tension;
+        }
+        return 0;
+    }
+    
+    getDistortion() {
+        if (this.glitchActive) {
+            return HORROR_CONFIG.horror.distortionIntensity * this.tension;
+        }
+        return 0;
+    }
+    
+    getTension() {
+        return this.tension;
+    }
+    
+    increaseTension(amount) {
+        this.tension = Math.min(this.tension + amount, HORROR_CONFIG.horror.maxTension);
+    }
+    
+    reset() {
+        this.tension = 0;
+        this.glitchActive = false;
+        this.shadowVisible = false;
+        this.whisperTriggered = false;
+        this.glitchTimer = 0;
+        this.shadowTimer = 0;
+        this.whisperTimer = 0;
+        
+        // Clear any active effects
+        const canvas = document.getElementById('gameCanvas');
+        if (canvas) {
+            canvas.style.filter = '';
+        }
+        
+        const warningLights = document.querySelectorAll('.warning-light');
+        warningLights.forEach(light => {
+            light.classList.remove('active');
+        });
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.HorrorSystem = HorrorSystem;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = HorrorSystem;
+}

--- a/game/js/main.js
+++ b/game/js/main.js
@@ -1,0 +1,7 @@
+// Browser bootstrap
+
+window.addEventListener('DOMContentLoaded', () => {
+    const game = new Game();
+    window.busShiftGame = game;
+    game.start();
+});

--- a/game/js/renderer.js
+++ b/game/js/renderer.js
@@ -1,0 +1,304 @@
+// Renderer Module - Handles all canvas drawing operations (Browser-first)
+
+const RENDERER_CONFIG = (typeof window !== 'undefined' && window.CONFIG)
+    ? window.CONFIG
+    : require('./config.js');
+
+const RENDERER_UTILS = (typeof window !== 'undefined' && window.Utils)
+    ? window.Utils
+    : require('./utils.js');
+
+class Renderer {
+    constructor(canvas, ctx) {
+        this.canvas = canvas;
+        this.ctx = ctx;
+        this.roadOffset = 0;
+        this.shakeX = 0;
+        this.shakeY = 0;
+        this.horizonY = RENDERER_CONFIG.canvas.height * 0.33;
+    }
+
+    clear() {
+        this.ctx.fillStyle = RENDERER_CONFIG.canvas.backgroundColor;
+        this.ctx.fillRect(0, 0, RENDERER_CONFIG.canvas.width, RENDERER_CONFIG.canvas.height);
+    }
+
+    applyShake(intensity) {
+        this.shakeX = RENDERER_UTILS.random(-intensity, intensity);
+        this.shakeY = RENDERER_UTILS.random(-intensity, intensity);
+    }
+
+    resetShake() {
+        this.shakeX = 0;
+        this.shakeY = 0;
+    }
+
+    render(gameState) {
+        this.clear();
+
+        this.ctx.save();
+        this.ctx.translate(this.shakeX, this.shakeY);
+
+        this.drawSky();
+        this.drawGround();
+        this.drawRoadPerspective(gameState);
+        this.drawRoadsideSilhouettes();
+        this.drawFog(gameState.tension || 0);
+        this.drawCockpit(gameState);
+
+        this.ctx.restore();
+    }
+
+    drawSky() {
+        const gradient = this.ctx.createLinearGradient(0, 0, 0, this.horizonY);
+        gradient.addColorStop(0, '#05070d');
+        gradient.addColorStop(1, '#141924');
+        this.ctx.fillStyle = gradient;
+        this.ctx.fillRect(0, 0, CONFIG.canvas.width, this.horizonY);
+    }
+
+    drawGround() {
+        const gradient = this.ctx.createLinearGradient(0, this.horizonY, 0, RENDERER_CONFIG.canvas.height);
+        gradient.addColorStop(0, '#0d0d0d');
+        gradient.addColorStop(1, '#050505');
+        this.ctx.fillStyle = gradient;
+        this.ctx.fillRect(0, this.horizonY, RENDERER_CONFIG.canvas.width, RENDERER_CONFIG.canvas.height - this.horizonY);
+    }
+
+    getRoadXAt(y, side = 'left', lateralOffset = 0) {
+        const centerX = RENDERER_CONFIG.canvas.width / 2 + lateralOffset;
+        const bottomWidth = RENDERER_CONFIG.road.width * 2.2;
+        const topWidth = RENDERER_CONFIG.road.width * 0.28;
+        const t = RENDERER_UTILS.clamp((y - this.horizonY) / (RENDERER_CONFIG.canvas.height - this.horizonY), 0, 1);
+        const halfWidth = RENDERER_UTILS.lerp(topWidth / 2, bottomWidth / 2, t);
+        return side === 'left' ? centerX - halfWidth : centerX + halfWidth;
+    }
+
+    drawRoadPerspective(gameState) {
+        const lateralOffset = -(gameState.bus?.x || 0) * 0.35;
+
+        const roadLeftTop = this.getRoadXAt(this.horizonY, 'left', lateralOffset);
+        const roadRightTop = this.getRoadXAt(this.horizonY, 'right', lateralOffset);
+        const roadLeftBottom = this.getRoadXAt(RENDERER_CONFIG.canvas.height + 40, 'left', lateralOffset);
+        const roadRightBottom = this.getRoadXAt(RENDERER_CONFIG.canvas.height + 40, 'right', lateralOffset);
+
+        this.ctx.fillStyle = '#161616';
+        this.ctx.beginPath();
+        this.ctx.moveTo(roadLeftTop, this.horizonY);
+        this.ctx.lineTo(roadRightTop, this.horizonY);
+        this.ctx.lineTo(roadRightBottom, RENDERER_CONFIG.canvas.height);
+        this.ctx.lineTo(roadLeftBottom, RENDERER_CONFIG.canvas.height);
+        this.ctx.closePath();
+        this.ctx.fill();
+
+        this.ctx.strokeStyle = '#5d5d5d';
+        this.ctx.lineWidth = 3;
+        this.ctx.beginPath();
+        this.ctx.moveTo(roadLeftTop, this.horizonY);
+        this.ctx.lineTo(roadLeftBottom, RENDERER_CONFIG.canvas.height);
+        this.ctx.moveTo(roadRightTop, this.horizonY);
+        this.ctx.lineTo(roadRightBottom, RENDERER_CONFIG.canvas.height);
+        this.ctx.stroke();
+
+        this.drawPerspectiveLaneMarkers(lateralOffset, gameState.speed || 0);
+    }
+
+    drawPerspectiveLaneMarkers(lateralOffset, speed) {
+        const segmentCount = 22;
+        const laneCount = RENDERER_CONFIG.road.lanes;
+        this.ctx.strokeStyle = '#f4f2c6';
+
+        for (let i = 0; i < segmentCount; i++) {
+            const z = ((i + this.roadOffset) % segmentCount) / segmentCount;
+            const nextZ = ((i + 0.45 + this.roadOffset) % segmentCount) / segmentCount;
+            const y = RENDERER_UTILS.lerp(this.horizonY, RENDERER_CONFIG.canvas.height, z);
+            const y2 = RENDERER_UTILS.lerp(this.horizonY, RENDERER_CONFIG.canvas.height, nextZ);
+
+            if (y2 <= this.horizonY + 4) continue;
+
+            const left1 = this.getRoadXAt(y, 'left', lateralOffset);
+            const right1 = this.getRoadXAt(y, 'right', lateralOffset);
+            const left2 = this.getRoadXAt(y2, 'left', lateralOffset);
+            const right2 = this.getRoadXAt(y2, 'right', lateralOffset);
+
+            const center1 = (left1 + right1) / 2;
+            const center2 = (left2 + right2) / 2;
+            this.ctx.lineWidth = RENDERER_UTILS.lerp(1, 6, z);
+
+            this.ctx.beginPath();
+            this.ctx.moveTo(center1, y);
+            this.ctx.lineTo(center2, y2);
+            this.ctx.stroke();
+
+            for (let lane = 1; lane < laneCount; lane++) {
+                const tLane = lane / laneCount;
+                const x1 = RENDERER_UTILS.lerp(left1, right1, tLane);
+                const x2 = RENDERER_UTILS.lerp(left2, right2, tLane);
+                this.ctx.strokeStyle = 'rgba(220,220,220,0.5)';
+                this.ctx.lineWidth = RENDERER_UTILS.lerp(1, 4, z) * 0.6;
+                this.ctx.beginPath();
+                this.ctx.moveTo(x1, y);
+                this.ctx.lineTo(x2, y2);
+                this.ctx.stroke();
+                this.ctx.strokeStyle = '#f4f2c6';
+            }
+        }
+
+        this.roadOffset += Utils.clamp(speed / 120, 0.02, 0.6);
+    }
+
+    drawRoadsideSilhouettes() {
+        const count = 28;
+        for (let i = 0; i < count; i++) {
+            const z = i / count;
+            const y = RENDERER_UTILS.lerp(this.horizonY + 10, RENDERER_CONFIG.canvas.height, z);
+            const width = RENDERER_UTILS.lerp(2, 18, z);
+            const height = RENDERER_UTILS.lerp(8, 120, z);
+
+            const leftX = this.getRoadXAt(y, 'left') - RENDERER_UTILS.lerp(20, 220, z);
+            const rightX = this.getRoadXAt(y, 'right') + RENDERER_UTILS.lerp(20, 220, z);
+
+            this.ctx.fillStyle = `rgba(10, 14, 10, ${RENDERER_UTILS.lerp(0.2, 0.9, z)})`;
+            this.ctx.fillRect(leftX, y - height, width, height);
+            this.ctx.fillRect(rightX, y - height, width, height);
+        }
+    }
+
+    drawFog(tension) {
+        const fog = RENDERER_UTILS.clamp(RENDERER_CONFIG.environment.fogDensity + tension * 0.32, 0.62, 0.96);
+        const gradient = this.ctx.createRadialGradient(
+            RENDERER_CONFIG.canvas.width / 2,
+            this.horizonY + 60,
+            0,
+            RENDERER_CONFIG.canvas.width / 2,
+            RENDERER_CONFIG.canvas.height / 2,
+            RENDERER_CONFIG.canvas.width * 0.8
+        );
+
+        gradient.addColorStop(0, 'rgba(42, 42, 42, 0.05)');
+        gradient.addColorStop(1, `rgba(42, 42, 42, ${fog})`);
+
+        this.ctx.fillStyle = gradient;
+        this.ctx.fillRect(0, 0, RENDERER_CONFIG.canvas.width, RENDERER_CONFIG.canvas.height);
+    }
+
+    drawCockpit(gameState) {
+        const dashboardTop = RENDERER_CONFIG.canvas.height - 195;
+
+        const panelGradient = this.ctx.createLinearGradient(0, dashboardTop, 0, CONFIG.canvas.height);
+        panelGradient.addColorStop(0, '#111');
+        panelGradient.addColorStop(1, '#050505');
+        this.ctx.fillStyle = panelGradient;
+        this.ctx.fillRect(0, dashboardTop, RENDERER_CONFIG.canvas.width, RENDERER_CONFIG.canvas.height - dashboardTop);
+
+        this.ctx.strokeStyle = '#2a2a2a';
+        this.ctx.lineWidth = 3;
+        this.ctx.beginPath();
+        this.ctx.moveTo(0, dashboardTop);
+        this.ctx.lineTo(RENDERER_CONFIG.canvas.width, dashboardTop);
+        this.ctx.stroke();
+
+        const clusterWidth = 360;
+        const clusterHeight = 62;
+        const clusterX = RENDERER_CONFIG.canvas.width / 2 - clusterWidth / 2;
+        const clusterY = dashboardTop + 12;
+
+        this.ctx.fillStyle = 'rgba(14, 14, 14, 0.9)';
+        this.ctx.strokeStyle = '#3a3a3a';
+        this.ctx.lineWidth = 2;
+        this.ctx.beginPath();
+        this.ctx.roundRect(clusterX, clusterY, clusterWidth, clusterHeight, 8);
+        this.ctx.fill();
+        this.ctx.stroke();
+
+        this.ctx.fillStyle = '#89ff7a';
+        this.ctx.font = 'bold 20px Courier New';
+        this.ctx.textAlign = 'left';
+        this.ctx.fillText(`${Math.round(gameState.speed || 0)} km/h`, clusterX + 14, clusterY + 39);
+
+        this.ctx.fillStyle = '#9aa3ad';
+        this.ctx.font = '14px Courier New';
+        this.ctx.fillText('Rota 66-B', clusterX + 200, clusterY + 25);
+        this.ctx.fillText('Noite / Neblina', clusterX + 200, clusterY + 45);
+
+        const wheelX = RENDERER_CONFIG.canvas.width * 0.5;
+        const wheelY = RENDERER_CONFIG.canvas.height - 74;
+        const wheelRadius = 76;
+        const steerAngle = RENDERER_UTILS.toRadians(gameState.bus?.steerAngle || 0);
+
+        this.ctx.save();
+        this.ctx.translate(wheelX, wheelY);
+        this.ctx.rotate(steerAngle);
+
+        this.ctx.strokeStyle = '#191919';
+        this.ctx.lineWidth = 16;
+        this.ctx.beginPath();
+        this.ctx.arc(0, 0, wheelRadius, 0, Math.PI * 2);
+        this.ctx.stroke();
+
+        this.ctx.strokeStyle = '#4a4a4a';
+        this.ctx.lineWidth = 6;
+        for (let i = 0; i < 3; i++) {
+            this.ctx.beginPath();
+            this.ctx.moveTo(0, 0);
+            this.ctx.lineTo(0, -wheelRadius + 8);
+            this.ctx.stroke();
+            this.ctx.rotate((Math.PI * 2) / 3);
+        }
+
+        this.ctx.fillStyle = '#1a1a1a';
+        this.ctx.beginPath();
+        this.ctx.arc(0, 0, 18, 0, Math.PI * 2);
+        this.ctx.fill();
+
+        this.ctx.restore();
+
+        this.drawIndicatorLights(gameState);
+    }
+
+    drawIndicatorLights(gameState) {
+        const y = RENDERER_CONFIG.canvas.height - 145;
+        const startX = RENDERER_CONFIG.canvas.width / 2 - 38;
+        const gap = 38;
+        const speed = gameState.speed || 0;
+        const fuel = gameState.fuel || 100;
+
+        const lights = [
+            { color: '#26ff00', active: speed > 1 },
+            { color: '#ffe100', active: fuel < 55 },
+            { color: '#ff6a00', active: gameState.offRoadTime > 0.5 }
+        ];
+
+        lights.forEach((light, index) => {
+            const x = startX + index * gap;
+            this.ctx.beginPath();
+            this.ctx.arc(x, y, 11, 0, Math.PI * 2);
+            this.ctx.fillStyle = light.active ? light.color : '#3a3a3a';
+            this.ctx.fill();
+            if (light.active) {
+                this.ctx.shadowColor = light.color;
+                this.ctx.shadowBlur = 20;
+                this.ctx.beginPath();
+                this.ctx.arc(x, y, 8, 0, Math.PI * 2);
+                this.ctx.fillStyle = light.color;
+                this.ctx.fill();
+                this.ctx.shadowBlur = 0;
+            }
+        });
+    }
+
+    updateRoadScroll(speed) {
+        this.roadOffset += speed * RENDERER_CONFIG.road.scrollSpeed * 0.001;
+        if (this.roadOffset > 1000) {
+            this.roadOffset = 0;
+        }
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.Renderer = Renderer;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Renderer;
+}

--- a/game/js/utils.js
+++ b/game/js/utils.js
@@ -1,0 +1,152 @@
+// Utility Functions for Bus Shift
+
+const Utils = {
+    /**
+     * Generate random number between min and max
+     */
+    random(min, max) {
+        return Math.random() * (max - min) + min;
+    },
+    
+    /**
+     * Generate random integer between min and max (inclusive)
+     */
+    randomInt(min, max) {
+        return Math.floor(Math.random() * (max - min + 1)) + min;
+    },
+    
+    /**
+     * Linear interpolation between two values
+     */
+    lerp(start, end, t) {
+        return start + (end - start) * t;
+    },
+    
+    /**
+     * Clamp a value between min and max
+     */
+    clamp(value, min, max) {
+        return Math.min(Math.max(value, min), max);
+    },
+    
+    /**
+     * Map a value from one range to another
+     */
+    map(value, inMin, inMax, outMin, outMax) {
+        return (value - inMin) * (outMax - outMin) / (inMax - inMin) + outMin;
+    },
+    
+    /**
+     * Calculate distance between two points
+     */
+    distance(x1, y1, x2, y2) {
+        const dx = x2 - x1;
+        const dy = y2 - y1;
+        return Math.sqrt(dx * dx + dy * dy);
+    },
+    
+    /**
+     * Calculate angle between two points
+     */
+    angle(x1, y1, x2, y2) {
+        return Math.atan2(y2 - y1, x2 - x1);
+    },
+    
+    /**
+     * Check if point is inside rectangle
+     */
+    pointInRect(px, py, rx, ry, rw, rh) {
+        return px >= rx && px <= rx + rw && py >= ry && py <= ry + rh;
+    },
+    
+    /**
+     * Check rectangle collision
+     */
+    rectCollision(r1x, r1y, r1w, r1h, r2x, r2y, r2w, r2h) {
+        return r1x < r2x + r2w &&
+               r1x + r1w > r2x &&
+               r1y < r2y + r2h &&
+               r1y + r1h > r2y;
+    },
+    
+    /**
+     * Ease in-out function
+     */
+    easeInOut(t) {
+        return t < 0.5 
+            ? 2 * t * t 
+            : -1 + (4 - 2 * t) * t;
+    },
+    
+    /**
+     * Ease in function
+     */
+    easeIn(t) {
+        return t * t;
+    },
+    
+    /**
+     * Ease out function
+     */
+    easeOut(t) {
+        return t * (2 - t);
+    },
+    
+    /**
+     * Choose random item from array
+     */
+    choose(array) {
+        return array[Math.floor(Math.random() * array.length)];
+    },
+    
+    /**
+     * Shuffle array
+     */
+    shuffle(array) {
+        const shuffled = [...array];
+        for (let i = shuffled.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+        }
+        return shuffled;
+    },
+    
+    /**
+     * Convert degrees to radians
+     */
+    toRadians(degrees) {
+        return degrees * Math.PI / 180;
+    },
+    
+    /**
+     * Convert radians to degrees
+     */
+    toDegrees(radians) {
+        return radians * 180 / Math.PI;
+    },
+    
+    /**
+     * Format number with leading zeros
+     */
+    pad(num, size) {
+        let s = num + "";
+        while (s.length < size) s = "0" + s;
+        return s;
+    },
+    
+    /**
+     * Deep clone object
+     */
+    deepClone(obj) {
+        return JSON.parse(JSON.stringify(obj));
+    }
+};
+
+if (typeof window !== 'undefined') {
+    window.Utils = Utils;
+}
+
+// Export for use in other modules
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Utils;
+}


### PR DESCRIPTION
Resumo
- Implementa protótipo da tela do motorista (cockpit/volante/HUD) em `game/`.
- Corrige compatibilidade para execução no navegador (substituição de requires por globais e bootstrap browser-first).
- Adiciona loop de jogo, sistema de horror (tensão, glitch, sombra), áudio básico e controles.

Arquivos principais
- game/index.html
- game/css/* (estilos + efeitos retro)
- game/js/* (config, utils, controls, renderer, horror, audio, game, main)

Testes realizados
- Fluxo manual E2E: start → dirigir → pausa/retomar → sair da pista → game over → restart (sem erros de console).
- Servidor local: http://localhost:8081/game/

Como testar localmente
1. npm start / python -m http.server 8081 na raiz do repo
2. Acessar `/game/`, pressionar `SPACE` para iniciar
3. Usar setas ou WASD para dirigir; validar HUD e mensagens

Notas
- Branch pronta para revisão; solicitar merge quando aprovado.
- Posso adicionar teste Playwright E2E automático se desejar.
